### PR TITLE
Harmonize UI across mini apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
       --bg: #f7f7fb; --card:#ffffff; --text:#222; --muted:#6b7280;
       --brand1:#ff7a59; --brand2:#f76707; --ok:#2d5a27;
     }
-    *{box-sizing:border-box} html,body{height:100%}
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,sans-serif;background:linear-gradient(135deg,#ffecd2 0%,#fcb69f 100%);}
+    *{margin:0;padding:0;box-sizing:border-box} html,body{height:100%}
+    body{margin:0;font-family:'Comic Sans MS',cursive,sans-serif;background:linear-gradient(135deg,#ffecd2 0%,#fcb69f 100%);}
     .wrap{min-height:100vh;display:grid;grid-template-rows:auto 1fr auto}
-    header{backdrop-filter:saturate(1.2) blur(6px);background:rgba(255,255,255,.86);padding:18px 16px;box-shadow:0 8px 24px rgba(0,0,0,.08)}
+    header{position:relative;grid-column:1/-1;background:rgba(255,255,255,.96);border-radius:20px;padding:clamp(8px,1.6vh,16px);text-align:center;box-shadow:0 10px 30px rgba(0,0,0,.1)}
     h1{margin:0;font-size:clamp(1.25rem,3.2vw,2rem);color:var(--brand1)}
-    .sub{color:var(--brand2);font-weight:600}
+    .sub{font-size:clamp(.9rem,2vh,1.1rem);color:var(--brand2)}
     main{padding:28px 16px}
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;max-width:1100px;margin:0 auto}
     .card{background:rgba(255,255,255,.96);border-radius:18px;padding:18px;box-shadow:0 10px 30px rgba(0,0,0,.12);display:flex;flex-direction:column;gap:12px;transition:transform .15s ease, box-shadow .15s}
@@ -23,9 +23,9 @@
     .card h2{margin:0;font-size:1.25rem;color:#333}
     .card p{margin:0;color:#444;line-height:1.4}
     .pill{display:inline-flex;align-items:center;gap:8px;background:linear-gradient(45deg,var(--brand1),var(--brand2));color:#fff;border-radius:999px;padding:6px 12px;font-weight:700}
-    .go{margin-top:8px;display:inline-flex;align-items:center;gap:8px;text-decoration:none;font-weight:700;color:#fff;background:#111;border-radius:12px;padding:10px 14px}
+    .go{margin-top:8px;display:inline-flex;align-items:center;gap:8px;text-decoration:none;font-weight:700;color:#fff;background:linear-gradient(45deg,var(--brand1),var(--brand2));border-radius:12px;padding:10px 14px}
     .go span{font-size:1.2rem}
-    footer{color:#333;display:flex;gap:10px;align-items:center;justify-content:center;padding:18px 10px}
+    footer{color:#333;display:flex;gap:10px;align-items:center;justify-content:center;padding:18px 10px;background:rgba(255,255,255,.96);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.1)}
     footer a{color:#222}
     .note{color:#222;background:rgba(255,255,255,.88);border-radius:12px;padding:10px 12px;max-width:1100px;margin:0 auto 16px auto}
     code{background:#111;color:#fff;border-radius:6px;padding:2px 6px}

--- a/maths/index.html
+++ b/maths/index.html
@@ -9,7 +9,7 @@
   html,body{height:100%}
   body{
     font-family:'Comic Sans MS',cursive,sans-serif;
-    background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);
+    background:linear-gradient(135deg,#ffecd2 0%,#fcb69f 100%);
     height:100vh; overflow:hidden;
     display:grid;
     grid-template-columns:280px 1fr 280px;
@@ -18,14 +18,14 @@
     padding:clamp(8px,1.6vh,16px);
   }
   .header{position:relative;grid-column:1 / -1;background:rgba(255,255,255,.95);border-radius:20px;padding:clamp(8px,1.6vh,16px);text-align:center;box-shadow:0 10px 30px rgba(0,0,0,.1)}
-  .header h1{color:#667eea;font-size:clamp(1.2rem,3vh,2rem);margin-bottom:clamp(4px,1vh,10px);text-shadow:2px 2px 4px rgba(0,0,0,.1)}
-  .time-display{font-size:clamp(.9rem,2vh,1.1rem);color:#764ba2;margin-bottom:clamp(6px,1vh,12px)}
+  .header h1{color:#ff7a59;font-size:clamp(1.2rem,3vh,2rem);margin-bottom:clamp(4px,1vh,10px);text-shadow:2px 2px 4px rgba(0,0,0,.1)}
+  .time-display{font-size:clamp(.9rem,2vh,1.1rem);color:#f76707;margin-bottom:clamp(6px,1vh,12px)}
 
   .left-panel,.main-area,.right-panel{background:rgba(255,255,255,.95);border-radius:20px;padding:clamp(10px,1.8vh,18px);box-shadow:0 10px 30px rgba(0,0,0,.1);min-height:0}
   .left-panel,.right-panel{display:flex;flex-direction:column;gap:clamp(10px,1.6vh,18px);overflow:auto}
   .main-area{padding:clamp(12px,2vh,22px);display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;overflow:hidden}
 
-  .panel-title{font-size:clamp(1rem,2.2vh,1.2rem);color:#667eea;font-weight:bold;margin-bottom:clamp(6px,1vh,10px);text-align:center;border-bottom:2px solid #f0f0f0;padding-bottom:clamp(6px,1vh,10px)}
+  .panel-title{font-size:clamp(1rem,2.2vh,1.2rem);color:#ff7a59;font-weight:bold;margin-bottom:clamp(6px,1vh,10px);text-align:center;border-bottom:2px solid #f0f0f0;padding-bottom:clamp(6px,1vh,10px)}
 
   .stats-grid{display:grid;grid-template-columns:1fr 1fr;gap:clamp(6px,1vh,12px)}
   .stat-card{background:linear-gradient(45deg,#ff9a9e,#fad0c4);border-radius:15px;padding:clamp(8px,1.4vh,14px);text-align:center;color:#fff;text-shadow:1px 1px 2px rgba(0,0,0,.3)}
@@ -47,12 +47,12 @@
 
   .answer-section{display:flex;flex-direction:column;align-items:center;gap:clamp(8px,1.4vh,14px);margin:clamp(10px,1.6vh,16px) 0}
   .answer-input{font-size:clamp(1.2rem,4vh,2rem);padding:clamp(8px,1.4vh,14px);border:3px solid #ddd;border-radius:20px;width:clamp(120px,20vw,220px);text-align:center;font-family:inherit;background:#f8f9ff;transition:border-color .3s}
-  .answer-input:focus{outline:none;border-color:#667eea;box-shadow:0 0 20px rgba(102,126,234,.3)}
+  .answer-input:focus{outline:none;border-color:#ff7a59;box-shadow:0 0 20px rgba(255,122,89,.3)}
 
   .btn-group{display:flex;gap:clamp(6px,1vh,12px)}
   .btn{font-size:clamp(1rem,2.2vh,1.1rem);padding:clamp(8px,1.4vh,12px) clamp(14px,2.5vh,22px);border:none;border-radius:25px;cursor:pointer;font-family:inherit;font-weight:bold;transition:transform .2s,box-shadow .2s}
   .btn:hover{transform:translateY(-3px);box-shadow:0 10px 20px rgba(0,0,0,.2)}
-  .btn-primary{background:linear-gradient(45deg,#667eea,#764ba2);color:#fff}
+  .btn-primary{background:linear-gradient(45deg,#ff7a59,#f76707);color:#fff}
   .btn-secondary{background:linear-gradient(45deg,#ffecd2,#fcb69f);color:#333}
   .btn-success{background:linear-gradient(45deg,#a8edea,#fed6e3);color:#2d5a27}
 
@@ -77,11 +77,11 @@
 
   .progress-section{background:#f8f9ff;border-radius:15px;padding:clamp(10px,1.6vh,16px)}
   .progress-bar{background:#e0e0e0;border-radius:15px;height:12px;margin:8px 0;overflow:hidden}
-  .progress-fill{background:linear-gradient(90deg,#667eea,#764ba2);height:100%;transition:width .3s ease;border-radius:15px}
-  .timer-display{background:linear-gradient(45deg,#667eea,#764ba2);color:#fff;padding:clamp(10px,1.6vh,14px);border-radius:15px;text-align:center;font-size:clamp(1rem,2.2vh,1.1rem);font-weight:bold}
+  .progress-fill{background:linear-gradient(90deg,#ff7a59,#f76707);height:100%;transition:width .3s ease;border-radius:15px}
+  .timer-display{background:linear-gradient(45deg,#ff7a59,#f76707);color:#fff;padding:clamp(10px,1.6vh,14px);border-radius:15px;text-align:center;font-size:clamp(1rem,2.2vh,1.1rem);font-weight:bold}
   .session-stats{display:grid;grid-template-columns:1fr 1fr;gap:clamp(6px,1vh,10px);margin-top:10px}
   .session-stat{background:#f0f8ff;padding:clamp(8px,1.2vh,12px);border-radius:10px;text-align:center}
-  .session-stat-number{font-size:clamp(1rem,2.2vh,1.1rem);font-weight:bold;color:#667eea}
+  .session-stat-number{font-size:clamp(1rem,2.2vh,1.1rem);font-weight:bold;color:#ff7a59}
 
   .celebration{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:1000}
   .confetti{position:absolute;width:10px;height:10px;background:#ff6b6b;animation:confetti-fall 3s linear forwards}
@@ -89,7 +89,7 @@
 
   .mode-selector{display:flex;gap:clamp(6px,1vh,10px);margin-bottom:clamp(8px,1.4vh,12px)}
   .mode-btn{flex:1;padding:clamp(8px,1.2vh,12px);border:2px solid #ddd;border-radius:15px;background:#fff;cursor:pointer;font-family:inherit;font-weight:bold;transition:all .3s}
-  .mode-btn.active{border-color:#667eea;background:linear-gradient(45deg,#667eea,#764ba2);color:#fff}
+  .mode-btn.active{border-color:#ff7a59;background:linear-gradient(45deg,#ff7a59,#f76707);color:#fff}
 
   @media (max-width:1200px){ body{grid-template-columns:240px 1fr 240px} }
   @media (max-width:900px){
@@ -101,7 +101,7 @@
 </head>
 <body>
     <div class="header">
-        <a href="../" style="position:absolute;top:clamp(8px,1.6vh,16px);right:clamp(8px,1.6vh,16px);padding:8px 12px;background:#667eea;color:white;text-decoration:none;border-radius:12px;font-size:clamp(.8rem,1.8vh,1rem);">Retour au menu</a>
+        <a href="../" style="position:absolute;top:clamp(8px,1.6vh,16px);right:clamp(8px,1.6vh,16px);padding:8px 12px;background:#ff7a59;color:white;text-decoration:none;border-radius:12px;font-size:clamp(.8rem,1.8vh,1rem);">Retour au menu</a>
         <h1>🎯 Les Maths de Romane ✨</h1>
         <div class="time-display" id="time-display">Bienvenue Romane ! Il est <span id="current-time"></span></div>
     </div>


### PR DESCRIPTION
## Summary
- Style the landing page with playful Comic Sans and shared brand colors
- Align the maths trainer with the same cheerful orange theme as the keyboard app

## Testing
- `npm test` (fails: enoent package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aacc3c429c832b9476ec58bb91d9cb